### PR TITLE
Update to match chapi.io documentation & new deployment URLs.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,7 +12,7 @@ advantage of by lucrative commercial entities for our efforts.
 
 -------------------------------------------------------------------------------
 New BSD License (3-clause)
-Copyright (c) 2020, Digital Bazaar, Inc.
+Copyright (c) 2020-2022, Digital Bazaar, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Demos:
 
 ## Security
 
-See https://github.com/digitalbazaar/credential-handler-polyfill#security
+See https://github.com/credential-handler/credential-handler-polyfill#security
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 Demos:
 
-1. [Demo Wallet](https://chapi-demo-wallet.digitalbazaar.com/)
-2. [Demo Issuer](https://chapi-demo-issuer.digitalbazaar.com/)
-3. [Demo Verifier](https://chapi-demo-verifier.digitalbazaar.com/)
+1. [Demo Wallet](https://wallet.example.chapi.io/)
+2. [Demo Issuer](https://issuer.example.chapi.io/)
+3. [Demo Verifier](https://verifier.example.chapi.io/)
 
 ## Background
 
@@ -48,4 +48,4 @@ Digital Bazaar: support@digitalbazaar.com
 
 ## License
 
-[New BSD License (3-clause)](LICENSE) © 2020 Digital Bazaar
+[New BSD License (3-clause)](LICENSE) © 2020-2022 Digital Bazaar

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict'
 

--- a/mock-user-management.js
+++ b/mock-user-management.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict'
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/digitalbazaar/chapi-demo-wallet.git"
+    "url": "https://github.com/credential-handler/chapi-demo-wallet.git"
   },
   "author": {
     "name": "Digital Bazaar, Inc.",
@@ -14,9 +14,9 @@
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/digitalbazaar/chapi-demo-wallet/issues"
+    "url": "https://github.com/credential-handler/chapi-demo-wallet/issues"
   },
-  "homepage": "https://github.com/digitalbazaar/chapi-demo-wallet",
+  "homepage": "https://github.com/credential-handler/chapi-demo-wallet",
   "dependencies": {},
   "devDependencies": {
     "http-server": "^0.12.3"

--- a/wallet-ui-get.html
+++ b/wallet-ui-get.html
@@ -48,7 +48,7 @@
 
     <ol>
       <li>Register a wallet with your browser (for example,
-        the <a href="https://chapi-demo-wallet.digitalbazaar.com/">Demo Wallet</a>).</li>
+        the <a href="https://wallet.example.chapi.io/">Demo Wallet</a>).</li>
       <li>Click the <strong>Login</strong> button.</li>
       <li>Click on a Share button next to an appropriate credential.</li>
     </ol>

--- a/wallet-ui-store.html
+++ b/wallet-ui-store.html
@@ -57,7 +57,7 @@
 
     <ol>
       <li>Register a wallet with your browser (for example,
-        the <a href="https://chapi-demo-wallet.digitalbazaar.com/">Demo Wallet</a>).</li>
+        the <a href="https://wallet.example.chapi.io/">Demo Wallet</a>).</li>
       <li>Click the <strong>Login</strong> button.</li>
     </ol>
 


### PR DESCRIPTION
### Updates to documentation
- Change variable names to match chap.io developer docs

### Updates to URLs
- Point to chapi-demo-[issuer/wallet/verifier] now deployed at https://[issuer/wallet/verifier].example.chapi.io

### Misc
- Update copyright
- Code was already on credential-handler-polyfill v3