### PR TITLE
Fixed broken `get()` query type check

### DIFF
--- a/wallet-ui-get.html
+++ b/wallet-ui-get.html
@@ -80,7 +80,7 @@
     const vp = event.credentialRequestOptions.web.VerifiablePresentation;
     const query = Array.isArray(vp.query) ? vp.query[0] : vp.query;
 
-    if(!query.type === 'QueryByExample') {
+    if(!(query.type === 'QueryByExample')) {
       throw new Error('Only QueryByExample requests are supported in demo wallet.');
     }
 

--- a/wallet-ui-get.html
+++ b/wallet-ui-get.html
@@ -80,7 +80,7 @@
     const vp = event.credentialRequestOptions.web.VerifiablePresentation;
     const query = Array.isArray(vp.query) ? vp.query[0] : vp.query;
 
-    if(!(query.type === 'QueryByExample')) {
+    if(query.type !== 'QueryByExample') {
       throw new Error('Only QueryByExample requests are supported in demo wallet.');
     }
 


### PR DESCRIPTION
Quick fix on a check for queries of type `QueryByExample`